### PR TITLE
feat(InfoViewController): show injected git commit hash & branch in info view

### DIFF
--- a/Sources/PippinAdapters/InfoViewController/InfoViewController.swift
+++ b/Sources/PippinAdapters/InfoViewController/InfoViewController.swift
@@ -208,7 +208,14 @@ private extension InfoViewController {
         appNameLabel.adjustsFontSizeToFitWidth = true
         appNameLabel.minimumScaleFactor = 0.7
 
-        let appInfoLabel = UILabel.label(withText: "\(environment.semanticVersion) build \(environment.currentBuild)", font: environment.fonts.text, textColor: textColor, alignment: .center)
+        var appInfo = "\(environment.semanticVersion) (\(environment.currentBuild))"
+        if let gitCommitHash = environment.gitCommitHash {
+            appInfo += " · \(gitCommitHash)"
+        }
+        if let gitBranch = environment.gitBranch, gitBranch != "master", gitBranch != "main" {
+            appInfo += " · \(gitBranch)"
+        }
+        let appInfoLabel = UILabel.label(withText: appInfo, font: environment.fonts.text, textColor: textColor, alignment: .center)
         appInfoLabel.adjustsFontForContentSizeCategory = true
 
         let stack = UIStackView(arrangedSubviews: [appNameLabel, appInfoLabel])

--- a/Sources/PippinCore/Components/Environment.swift
+++ b/Sources/PippinCore/Components/Environment.swift
@@ -57,6 +57,11 @@ public class Environment: NSObject {
     public let lastLaunchedBuild: Build?
     public let lastLaunchedVersion: SemanticVersion?
 
+    /// The short git commit hash injected at build time by `inject-git-info`, or `nil` if it wasn't injected.
+    public let gitCommitHash: String?
+    /// The git branch name injected at build time by `inject-git-info`, or `nil` if it wasn't injected.
+    public let gitBranch: String?
+
     // MARK: infrastructure
     public var model: Model?
     public var crashReporter: CrashReporter?
@@ -111,6 +116,8 @@ public class Environment: NSObject {
         self.appName = bundle.getAppName()
         self.semanticVersion = bundle.getSemanticVersion()
         self.currentBuild = bundle.getBuild()
+        self.gitCommitHash = bundle.gitCommitHash
+        self.gitBranch = bundle.gitBranch
         self.defaults = defaults
         self.fonts = fonts
         self.sharedAssetsBundle = sharedAssetsBundle
@@ -149,6 +156,8 @@ public class Environment: NSObject {
         self.appName = bundle.getAppName()
         self.semanticVersion = bundle.getSemanticVersion()
         self.currentBuild = bundle.getBuild()
+        self.gitCommitHash = bundle.gitCommitHash
+        self.gitBranch = bundle.gitBranch
         self.defaults = defaults
         self.sharedAssetsBundle = sharedAssetsBundle
 


### PR DESCRIPTION
Resolves [PPN-6](https://linear.app/pippin-linear/issue/PPN-6/include-the-injected-git-info-in-the-info-view).

Displays the git info injected at build time by `inject-git-info` next to the version/build in the info view, reading like:

```
1.0.0 (3) · f3f14ad · some-branch
```

- The commit hash is appended when present.
- The branch is appended only when it isn't `master`/`main`.
- `gitCommitHash`/`gitBranch` are plumbed through `Environment` from `Bundle.main`, alongside the existing `semanticVersion`/`currentBuild`, using the `Bundle.gitCommitHash`/`Bundle.gitBranch` extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)